### PR TITLE
Fix PHP 7 syntax error

### DIFF
--- a/mpdf/mpdf.php
+++ b/mpdf/mpdf.php
@@ -1419,7 +1419,6 @@ function _getPageFormat($format) {
 			case 'A': {$format=array(314.65,504.57 );	 break;}		//	'A' format paperback size 111x178mm
 			case 'DEMY': {$format=array(382.68,612.28 );  break;}		//	'Demy' format paperback size 135x216mm
 			case 'ROYAL': {$format=array(433.70,663.30 );  break;}	//	'Royal' format paperback size 153x234mm
-			default: $format = false;
 		}
 	return $format;
 }


### PR DESCRIPTION
A duplicate default statement in a switch block is not allowed.
It yielded somewhat unpredictable behavior in previous versions
of PHP, but now throws a fatal error.

See https://github.com/facebook/hhvm/issues/3822.

Would be very cool to have a new release with this fix. :)