### PR TITLE
PHP 7.3 and WordPress 5.x

### DIFF
--- a/mpdf/mpdf.php
+++ b/mpdf/mpdf.php
@@ -30644,8 +30644,12 @@ class mPDF
 			} else {
 				$size *= $maxsize * 2;
 			}
-		} else
+		} else {
+			if (!is_numeric($size)) {
+				$size = 0;
+			}
 			$size *= (25.4 / $this->dpi); //nothing == px
+		}
 
 		return $size;
 	}

--- a/myfilters.inc.php
+++ b/myfilters.inc.php
@@ -27,12 +27,12 @@ function mpdf_myfilters( $content ) {
 }
 
 function mpdf_fixRelativUrls( $content ) {
-	$base_url = get_option( 'siteurl' );
+	$base_url = home_url();
 
 	if ( preg_match_all( '#<a.*href="(.*)".*>#iU', $content, $matches ) ) {
 		foreach ( $matches[1] as $ikey => $link ) {
 			if ( substr( $link, 0, 1 ) === '/' ) {
-				$content = str_replace( 'href="' . $link . '"', 'href="' . $base_url . '/' . $link . '"', $content );
+				$content = str_replace( 'href="' . $link . '"', 'href="' . $base_url . $link . '"', $content );
 			}
 		}
 	}
@@ -40,7 +40,7 @@ function mpdf_fixRelativUrls( $content ) {
 	if ( preg_match_all( "#<a.*href='(.*)'.*>#iU", $content, $matches ) ) {
 		foreach ( $matches[1] as $ikey => $link ) {
 			if ( substr( $link, 0, 1 ) === '/' ) {
-				$content = str_replace( "href='" . $link . "'", "href='" . $base_url . '/' . $link . "'", $content );
+				$content = str_replace( "href='" . $link . "'", "href='" . $base_url . $link . "'", $content );
 			}
 		}
 	}

--- a/wp-mpdf.php
+++ b/wp-mpdf.php
@@ -80,6 +80,16 @@ function mpdf_install() {
 	}
 }
 
+function mpdf_filename ($filename) {
+    return str_replace('.' . mpdf_extension($filename), '', $filename);
+}
+
+function mpdf_extension ($filename) {
+    $filename = substr($filename, strrpos($filename, '.'));
+
+    return strtolower(str_replace('.', '', $filename));
+}
+
 function mpdf_output( $wp_content = '', $do_pdf = false, $outputToBrowser = true, $pdfName = '', $templatePath = '' ) {
 	global $post;
 	$pdf_ofilename = $post->post_name . '.pdf';
@@ -460,9 +470,11 @@ function mpdf_exec( $outputToBrowser = '' ) {
 			$templateFile = $templatePath . get_option( 'mpdf_theme' ) . '.php';
 		}
 
+        $pdfName = isset($dsatz->pdfname) ? $dsatz->pdfname : '';
+
 		$pdf_output = '';
 		require( $templateFile );
-		mpdf_output( $pdf_output, true, $outputToBrowser, $dsatz->pdfname, $templatePath );
+		mpdf_output( $pdf_output, true, $outputToBrowser, $pdfName, $templatePath );
 
 		if ( $outputToBrowser == true ) {
 			exit;

--- a/wp-mpdf_admin.php
+++ b/wp-mpdf_admin.php
@@ -1,10 +1,10 @@
 <?php
 /*
  * This file is part of wp-mpdf.
- * wp-mpdf is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free  
+ * wp-mpdf is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free
  * Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * wp-mpdf is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  
+ * wp-mpdf is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with wp-mpdf. If not, see <http://www.gnu.org/licenses/>.
@@ -58,43 +58,35 @@ function mpdf_admin_options() {
 
 	echo '<form action="?page=' . $_GET['page'] . '" method="post">';
 	echo '<table border="0">';
-	echo '<tr><td>Thema: </td><td>';
+	echo '<tr><td>Theme: </td><td>';
 	echo '<select name="theme">';
-	//Search for Themes
-	$existingFiles = array();
-	$path          = dirname( __FILE__ ) . '/../../wp-mpdf-themes/';
-	if ( is_dir( $path ) ) {
-		if ( $dir = opendir( $path ) ) {
-			while ( $file = readdir( $dir ) ) {
-				if ( ! is_dir( $path . $file ) && $file != "." && $file != ".." ) {
-					if ( strtolower( substr( $file, count( $file ) - 4 ) ) == 'php' ) {
-						$existingFiles[] = $file;
-						echo '<option value="' . substr( $file, 0, count( $file ) - 5 ) . '" ';
-						if ( get_option( 'mpdf_theme' ) == substr( $file, 0, count( $file ) - 5 ) ) {
-							echo 'selected="selected"';
-						}
-						echo '>' . str_replace( '_', ' ', substr( $file, 0, count( $file ) - 5 ) ) . '</option>';
-					}
-				}
-			}
-		}
-	}
-	$path = dirname( __FILE__ ) . '/themes/';
-	if ( is_dir( $path ) ) {
-		if ( $dir = opendir( $path ) ) {
-			while ( $file = readdir( $dir ) ) {
-				if ( ! is_dir( $path . $file ) && $file != "." && $file != ".." ) {
-					if ( strtolower( substr( $file, count( $file ) - 4 ) ) == 'php' && ! in_array( $file, $existingFiles ) ) {
-						echo '<option value="' . substr( $file, 0, count( $file ) - 5 ) . '" ';
-						if ( get_option( 'mpdf_theme' ) == substr( $file, 0, count( $file ) - 5 ) ) {
-							echo 'selected="selected"';
-						}
-						echo '>' . str_replace( '_', ' ', substr( $file, 0, count( $file ) - 5 ) ) . '</option>';
-					}
-				}
-			}
-		}
-	}
+
+    // Search for Themes
+    $existingFiles = array();
+    $themes_path   = array(
+        dirname( __FILE__ ) . '/../../wp-mpdf-themes/',
+        dirname( __FILE__ ) . '/themes/'
+    );
+
+    foreach ($themes_path as $path) {
+        if (is_dir($path) && $dir = opendir($path)) {
+            while ($file = readdir($dir)) {
+                if (is_dir($path . $file) || $file === '.' || $file === '..') {
+                    continue;
+                }
+
+                if ( mpdf_extension( $file ) !== 'php' || in_array( $file, $existingFiles ) ) {
+                    continue;
+                }
+
+                $filename = mpdf_filename($file);
+                $existingFiles[] = $file;
+
+                echo '<option value="' . $filename . '" ' . selected( get_option( 'mpdf_theme' ), $filename, false ) . '>';
+                echo str_replace( '_', ' ', $filename ) . '</option>';
+            }
+    	}
+    }
 
 	echo '</select>';
 	echo '</td></tr>';


### PR DESCRIPTION
Small fixes to make compatible with latest versions of PHP and WP.

- Change siteurl to home_url because URL was generating incorrectly when both are not the same.
- Change the way themes are detected, it was improved to add more paths.
- MPDF errors to make it compatible with PHP 7.3.