### PR TITLE
Small fixes required to install plugin on large WP installs

### DIFF
--- a/cache/.htaccess
+++ b/cache/.htaccess
@@ -1,2 +1,0 @@
-Order deny,allow
-Deny from all

--- a/wp-mpdf.php
+++ b/wp-mpdf.php
@@ -3,7 +3,7 @@
 Plugin Name: wp-mpdf
 Plugin URI: https://fkrauthan.de/projects/php/wp-mpdf.html
 Description: Print a wordpress page as PDF with optional Geshi Parsing.
-Version: 3.7.1
+Version: 3.7.2
 Author: Florian 'fkrauthan' Krauthan
 Author URI: http://fkrauthan.de
 
@@ -539,19 +539,19 @@ function mpdf_admin_printeditbox() {
 
 	echo '<table border="0">';
 	echo '<tr><td>Put on whitelist/blacklist:</td><td><input ';
-	if ( $datas->general == true ) {
+	if ( $datas && $datas->general == true ) {
 		echo 'checked="checked" ';
 	}
 	echo 'type="checkbox" name="wp_mpdf_candownload" /></td></tr>';
 
 	echo '<tr><td>' . __( 'Put on whitelist/blacklist for need Login', 'wp-mpdf' ) . '</td><td><input ';
-	if ( $datas->login == true ) {
+	if ( $datas && $datas->login == true ) {
 		echo 'checked="checked" ';
 	}
 	echo 'type="checkbox" name="wp_mpdf_needlogin" /></td></tr>';
 
 	echo '<tr><td>' . __( 'Set a special PDF output name', 'wp-mpdf' ) . ':</td><td><input type="text" name="wp_mpdf_pdfname" value="';
-	echo esc_attr($datas->pdfname);
+	echo $datas ? esc_attr($datas->pdfname) : '';
 	echo '" /> (' . __( 'without .pdf at the end', 'wp-mpdf' ) . ')</td></tr>';
 	echo '</table>';
 }

--- a/wp-mpdf.php
+++ b/wp-mpdf.php
@@ -403,15 +403,18 @@ function mpdf_pdfbutton( $opennewtab = false, $buttontext = '', $logintext = 'Lo
 }
 
 function mpdf_getcachedir() {
-	$directory = plugin_dir_path( __FILE__ ) . '/cache/';
-	if ( ! is_dir( $directory ) || ! is_writable( $directory ) ) {
-		$directory = WP_CONTENT_DIR . '/wp-mpdf-themes/cache/';
-		if ( ! is_dir( $directory ) || ! is_writable( $directory ) ) {
-			die( 'wp-mpdf can\'t access cache directory. Please verify your setup!' );
-		}
+
+	$sCacheDirPath = WP_CONTENT_DIR . '/uploads/wp-mpdf/';
+	if( !is_dir($sCacheDirPath) ){
+		mkdir($sCacheDirPath);
 	}
 
-	return $directory;
+	if( !is_writable($sCacheDirPath) ){
+		die( "wp-mpdf can\'t access cache directory in $sCacheDirPath - Please verify your setup!" );
+	}
+
+	return $sCacheDirPath;
+
 }
 
 function mpdf_readcachedfile( $name, $pdfname ) {

--- a/wp-mpdf_admin.php
+++ b/wp-mpdf_admin.php
@@ -634,6 +634,9 @@ function mpdf_admin_cache() {
 	echo '<h2>Cache</h2>';
 	$path = mpdf_getcachedir();
 
+	$aUploadDir = wp_get_upload_dir();
+	$sUploadUrl = $aUploadDir['baseurl'] .'/wp-mpdf/';
+
 	if ( ! check_nonce_if_param_exists_in_request( array( 'delfile', 'clearcache' ), array() ) ) {
 		echo '<p style="color: red;">Illegal Access!</p>';
 
@@ -674,7 +677,7 @@ function mpdf_admin_cache() {
 					$pdffilename = substr( $file, 0, strlen( $file ) - 6 );
 					echo '<tr>';
 					echo '<td style="padding: 5px;">' . esc_html( file_get_contents( plugin_dir_path( __FILE__ ) . 'cache/' . $file ) ) . '</td>';
-					echo '<td style="padding: 5px;"><a href="' . esc_url( plugin_dir_url( __FILE__ ) . 'cache/' . $pdffilename ) . '">' . esc_html( $pdffilename ) . '</a></td>';
+					echo '<td style="padding: 5px;"><a href="' . esc_url( $sUploadUrl . $pdffilename ) . '">' . esc_html( $pdffilename ) . '</a></td>';
 					echo '<td style="padding: 5px;"><a href="?page=' . esc_attr($_GET['page']) . '&amp;delfile=' . esc_attr( $pdffilename ) . '&amp;' . $nonceURL . '">Delete</a></td>';
 					echo '</tr>';
 				}

--- a/wp-mpdf_admin.php
+++ b/wp-mpdf_admin.php
@@ -59,15 +59,15 @@ function mpdf_admin_find_themes() {
 }
 
 function mpdf_admin_find_users() {
-	global $wpdb;
-	$userIds = $wpdb->get_results( 'SELECT ID FROM ' . $wpdb->users . ' ORDER BY user_nicename ASC' );
 
-	$result = array();
-	foreach ( $userIds as $iUserID ) {
-		$result[] = $iUserID->ID;
-	}
+	$aUserQueryArgs = [
+		'role' => 'administrator',
+		'fields' => 'ID'
+	];
 
-	return $result;
+	$oUserQuery = new WP_User_Query($aUserQueryArgs);
+	return $oUserQuery->get_results();
+
 }
 
 function mpdf_admin_options() {

--- a/wp-mpdf_admin.php
+++ b/wp-mpdf_admin.php
@@ -632,7 +632,7 @@ function mpdf_admin_loginneededpages() {
 
 function mpdf_admin_cache() {
 	echo '<h2>Cache</h2>';
-	$path = plugin_dir_path( __FILE__ ) . 'cache/';
+	$path = mpdf_getcachedir();
 
 	if ( ! check_nonce_if_param_exists_in_request( array( 'delfile', 'clearcache' ), array() ) ) {
 		echo '<p style="color: red;">Illegal Access!</p>';


### PR DESCRIPTION
1. 1d1a76276b3791dd28b8645075645d72faeec7be -> in plugin dashboard the function mpdf_admin_find_users() tries to query all users in wp_users; on installations with thousands of users, this query will cause a memory exhausted error: I limited to users with role = administrator
2. c6187716e4ac84213250a3806062d8001ca3dfdb -> these additional check will avoid showing errors in PHP > 8
3. 4cbe66f68cc55693ee9321fe233c4d1171f005a9 -> mpdf_getcachedir() move user data outside the plugin folder, into uploads: this edit allow the plugin to be installed in multi-server config where plugins are not continuously monitored for changes, while uploads folder is normally shared between servers
4. f4f837334e5cc9057200ff62e3845f151e0a4141 -> align admin dashboard to list cached files from the folder returned by function mpdf_getcachedir()
5. e44b3854e1709fa70f44d5bc2934f32a1911bab2 -> updated the list of cached files in admin dashboard to link to the files inside wp-content/uploads/wp-mpdf